### PR TITLE
Fix: Allow multi-chunk responses

### DIFF
--- a/lib/ssh-exec.js
+++ b/lib/ssh-exec.js
@@ -16,7 +16,7 @@
       end = _.once(function () { ssh.end(); }),
 
       lastError,
-      response,
+      response = '',
       ret = _.once(function () { callback(lastError, response); });
 
     ssh
@@ -29,7 +29,7 @@
 
           stream
             .on('data', function (data) {
-              response = data.toString();
+              response += data.toString();
             })
             .on('exit', function () {
               end();


### PR DESCRIPTION
This fix appropriately appends "multi-part" responses returned from ssh2, such as "grep" commands. The full result is returned at command completion.

Without this fix I was getting just the last chunk of data from my grep on a remote server.
With this fix applied I get all results that are printed by the grep command in a single large string (as desired).
